### PR TITLE
Json model serialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.1'
+        classpath 'com.android.tools.build:gradle:8.1.2'
     }
 }
 
@@ -145,4 +145,6 @@ dependencies {
     androidTestImplementation 'org.mockito:mockito-android:5.8.0'
 
     androidTestUtil 'androidx.test:orchestrator:1.4.2'
+
+    implementation 'com.google.code.gson:gson:2.8.8'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.2'
+        classpath 'com.android.tools.build:gradle:8.2.1'
     }
 }
 

--- a/src/main/java/de/dennisguse/opentracks/TrackStoppedActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackStoppedActivity.java
@@ -8,6 +8,7 @@ import android.view.View;
 import android.widget.ArrayAdapter;
 
 import de.dennisguse.opentracks.data.ContentProviderUtils;
+import de.dennisguse.opentracks.data.interfaces.JSONSerializable;
 import de.dennisguse.opentracks.data.models.ActivityType;
 import de.dennisguse.opentracks.data.models.DistanceFormatter;
 import de.dennisguse.opentracks.data.models.SpeedFormatter;
@@ -46,6 +47,21 @@ public class TrackStoppedActivity extends AbstractTrackDeleteActivity implements
 
         ContentProviderUtils contentProviderUtils = new ContentProviderUtils(this);
         Track track = contentProviderUtils.getTrack(trackId);
+
+        //Temporary code to illustrate JSON serialization and loading of Track model
+        //TODO! - Remove
+        //Assignee - Jean Robatto
+
+        final String JSON_SERIALIZER_LOG_TAG = "JSONSerializerTest";
+
+        final String trackJSONString = track.toJSON();
+        Log.i(JSON_SERIALIZER_LOG_TAG, trackJSONString);
+
+        final Track trackCopy = JSONSerializable.fromJSON(trackJSONString, Track.class);
+        Log.i(JSON_SERIALIZER_LOG_TAG, trackCopy.toString());
+        Log.i(JSON_SERIALIZER_LOG_TAG, trackCopy.getName());
+
+        //End
 
         viewBinding.trackEditName.setText(track.getName());
 

--- a/src/main/java/de/dennisguse/opentracks/data/interfaces/JSONSerializable.java
+++ b/src/main/java/de/dennisguse/opentracks/data/interfaces/JSONSerializable.java
@@ -1,0 +1,33 @@
+package de.dennisguse.opentracks.data.interfaces;
+
+import com.google.gson.Gson;
+
+/**
+ * Adds JSON serialization to a class using the Google gson library.
+ * Allows nesting and exposing individual attributes with the @Expose tag.
+ * @param <T> Reference to implementing class type.
+ */
+public interface JSONSerializable<T> {
+
+    /**
+     * Serialize current object to a JSON string.
+     * NOTE - Only exposed attributes will be included (see @Expose).
+     * @return JSON String representation of object.
+     */
+    default String toJSON() {
+        final Gson gson = new Gson();
+        return gson.toJson(this);
+    }
+
+    /**
+     * Loads an object from a JSON string.
+     * @param json Serialized JSON string representation of object
+     * @param type Reference to expected class return type
+     * @return A new instance of T populated with data from json
+     * @param <T> Reference to expected class return type
+     */
+    static <T> T fromJSON(final String json, final Class<T> type) {
+        final Gson gson = new Gson();
+        return gson.fromJson(json, type);
+    }
+}

--- a/src/main/java/de/dennisguse/opentracks/data/models/Track.java
+++ b/src/main/java/de/dennisguse/opentracks/data/models/Track.java
@@ -28,6 +28,7 @@ import java.time.ZoneOffset;
 import java.util.Objects;
 import java.util.UUID;
 
+import de.dennisguse.opentracks.data.interfaces.JSONSerializable;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 
 /**
@@ -37,18 +38,23 @@ import de.dennisguse.opentracks.stats.TrackStatistics;
  * @author Rodrigo Damazio
  */
 //TODO Do not default initialize attributes; might be confusing for debugging
-public class Track {
+public class Track implements JSONSerializable<Track> {
 
     private Track.Id id;
+
+
     private UUID uuid = UUID.randomUUID();
 
+
     private String name = "";
+
     private String description = "";
     private String activityTypeLocalized = "";
 
     private ActivityType activityType;
 
     private final ZoneOffset zoneOffset;
+
 
     private TrackStatistics trackStatistics = new TrackStatistics();
 


### PR DESCRIPTION
**Describe the pull request**
This PR adds a JSONSerializable interface for data models, with the default methods fromJSON and toJSON.
Optionally, serialization can be fine tuned with the @Exposed annotation

**Link to the the issue**
https://github.com/rilling/OpenTracks-Winter-2024-COMP-354/issues/30

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Google gson standard Android library - a lightweight tool to work with JSON in Java
