### PR TITLE
feat: create basic crud operations

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackStoppedActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackStoppedActivity.java
@@ -56,14 +56,14 @@ public class TrackStoppedActivity extends AbstractTrackDeleteActivity implements
         //TODO! - Remove
         //Assignee - Jean Robatto
 
-        final String JSON_SERIALIZER_LOG_TAG = "JSONSerializerTest";
-
-        final String trackJSONString = track.toJSON();
-        Log.i(JSON_SERIALIZER_LOG_TAG, trackJSONString);
-
-        final Track trackCopy = JSONSerializable.fromJSON(trackJSONString, Track.class);
-        Log.i(JSON_SERIALIZER_LOG_TAG, trackCopy.toString());
-        Log.i(JSON_SERIALIZER_LOG_TAG, trackCopy.getName());
+//        final String JSON_SERIALIZER_LOG_TAG = "JSONSerializerTest";
+//
+//        final String trackJSONString = track.toJSON();
+//        Log.i(JSON_SERIALIZER_LOG_TAG, trackJSONString);
+//
+//        final Track trackCopy = JSONSerializable.fromJSON(trackJSONString, Track.class);
+//        Log.i(JSON_SERIALIZER_LOG_TAG, trackCopy.toString());
+//        Log.i(JSON_SERIALIZER_LOG_TAG, trackCopy.getName());
 
         //End
 

--- a/src/main/java/de/dennisguse/opentracks/data/models/CRUDConstants.java
+++ b/src/main/java/de/dennisguse/opentracks/data/models/CRUDConstants.java
@@ -1,0 +1,32 @@
+package de.dennisguse.opentracks.data.models;
+
+/**
+ * Keeps a list of constants that are useful to perform CRUD operations.
+ * The constants include collection names, CRUD operations, ERROR and SUCCESS messages
+ */
+public class CRUDConstants {
+    // Collection names
+    public static final String RUNS_TABLE = "runs";
+    public static final String USERS_TABLE = "users";
+
+    // CRUD tags - will show on success
+    public static final String TAG_CREATED = "CREATED";
+    public static final String TAG_UPDATED = "UPDATED";
+    public static final String TAG_DELETED = "DELETED";
+    public static final String TAG_GET = "GET";
+
+    // Error tag
+    public static final String TAG_ERROR = "ERROR";
+
+    // Error messages
+    public static final String ERROR_CREATING_DOCUMENT = "Error creating entry: ";
+    public static final String ERROR_UPDATING_DOCUMENT = "Error updating entry: ";
+    public static final String ERROR_DELETING_DOCUMENT = "Error deleting entry: ";
+    public static final String ERROR_RETRIEVING_ENTRY = "Error retrieving entry: ";
+
+    // Success messages
+    public static final String SUCCESS_CREATING_DOCUMENT = "Success creating entry: ";
+    public static final String SUCCESS_UPDATING_DOCUMENT = "Success updating entry: ";
+    public static final String SUCCESS_DELETING_DOCUMENT = "Success deleting entry: ";
+    public static final String SUCCESS_RETRIEVING_ENTRY = "Success retrieving entry: ";
+}

--- a/src/main/java/de/dennisguse/opentracks/util/FirestoreCRUDUtil.java
+++ b/src/main/java/de/dennisguse/opentracks/util/FirestoreCRUDUtil.java
@@ -1,0 +1,102 @@
+package de.dennisguse.opentracks.util;
+
+import android.util.Log;
+
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QuerySnapshot;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.firestore.DocumentSnapshot;
+
+import java.util.Map;
+
+import de.dennisguse.opentracks.data.models.CRUDConstants;
+
+/**
+ * Util class the performs CRUD operations on a given collection and handles
+ * onSuccess and onError callbacks.
+ */
+public class FirestoreCRUDUtil {
+    private FirebaseFirestore db;
+
+    public FirestoreCRUDUtil() {
+        db = FirebaseFirestore.getInstance(); // TODO: Singleton pattern will be implemented later, use it
+    }
+
+    /**
+     * Creates a new entry in db
+     * @param collection The collection in which to create the entry ("users" or "runs")
+     * @param data The data to be added as the new entry
+     */
+    public void createEntry(final String collection, final Map<String, Object> data) {
+        String id = data.get("id").toString();
+        db.collection(collection)
+                .document(id).set(data)
+                .addOnSuccessListener(documentReference-> {
+                    Log.d(CRUDConstants.TAG_CREATED, CRUDConstants.SUCCESS_CREATING_DOCUMENT + id);
+                })
+                .addOnFailureListener(e-> {
+                    Log.e(CRUDConstants.TAG_ERROR, CRUDConstants.ERROR_CREATING_DOCUMENT + e.getMessage());
+                });
+    }
+
+    /**
+     * Updates an existing entry in db
+     * @param collection The collection containing the entry to be updated
+     * @param data The new data to be updated in the entry
+     * TODO: discuss with the team, as I currently expect uniqueKey to be part of the data itself
+     * TODO: make each table to have a  unique ID
+     */
+    public void updateEntry(final String collection, final Map<String, Object> data) {
+        String id = data.get("id").toString();
+        db.collection(collection).document(id)
+                .update(data)
+                .addOnSuccessListener(documentReference-> {
+                    Log.d(CRUDConstants.TAG_UPDATED, CRUDConstants.SUCCESS_UPDATING_DOCUMENT + id);
+                })
+                .addOnFailureListener(e-> {
+                    Log.e(CRUDConstants.TAG_ERROR, CRUDConstants.ERROR_UPDATING_DOCUMENT + e.getMessage());
+                });
+    }
+
+    /**
+     * Deletes an existing entry in db
+     * @param collection The collection containing the entry to be updated
+     * @param data The new data to be updated in the entry
+     * TODO: discuss with the team, as I currently expect uniqueKey to be part of the data itself
+     * TODO: make each table to have a  unique ID
+     */
+    public void deleteEntry(final String collection, final Map<String, Object> data) {
+        String id = data.get("id").toString();
+        db.collection(collection).document(id)
+                .delete()
+                .addOnSuccessListener(documentReference -> {
+                    Log.d(CRUDConstants.TAG_DELETED, CRUDConstants.SUCCESS_DELETING_DOCUMENT + id);
+                })
+                .addOnFailureListener(e -> {
+                    Log.e(CRUDConstants.TAG_ERROR, CRUDConstants.ERROR_DELETING_DOCUMENT + e.getMessage());
+                });
+    }
+
+    /**
+     * Gets an existing entry in db
+     * @param collection The collection containing the entry to be updated
+     * @param data The new data to be updated in the entry
+     * TODO: discuss with the team, as I currently expect uniqueKey to be part of the data itself
+     * TODO: make each table to have a  unique ID
+     */
+    public void getEntry(final String collection, final Map<String, Object> data) {
+        String id = data.get("id").toString();
+        db.collection(collection).document(id)
+                .get()
+                .addOnSuccessListener(documentSnapshot -> {
+                    Log.d(CRUDConstants.TAG_GET, CRUDConstants.SUCCESS_RETRIEVING_ENTRY + id);
+                })
+                .addOnFailureListener(e -> {
+                    Log.e(CRUDConstants.TAG_ERROR, CRUDConstants.ERROR_RETRIEVING_ENTRY + e.getMessage());
+                });
+    }
+}


### PR DESCRIPTION
Previous MR created [HERE](https://github.com/Picard4/OpenTracks-Winter-2024-COMP-354-Groups-13-14-15/pull/4
), had to close it because even after rebasing to `group13` I had a lot of conflicts. 

Please treat this as the new MR:

**Describe the pull request**
A util method for CRUD operations. 

# Validation
### **C**reate 
 Adds a new run to the db when the user saves their run by pressing the following icon:
<img width="79" alt="image" src="https://github.com/Picard4/OpenTracks-Winter-2024-COMP-354-Groups-13-14-15/assets/31352301/403f22b7-9fc3-4c93-bb2b-3a0ca368f66c">

Code:
```js  
  FirestoreCRUDUtil firestoreCRUD = new FirestoreCRUDUtil();
  firestoreCRUD.createEntry("runs", run);
 
```
Results:
<img width="1303" alt="image" src="https://github.com/Picard4/OpenTracks-Winter-2024-COMP-354-Groups-13-14-15/assets/31352301/8c063ee6-aae9-4f32-ba3a-a0ac072bb819">
<img width="667" alt="image" src="https://github.com/Picard4/OpenTracks-Winter-2024-COMP-354-Groups-13-14-15/assets/31352301/408d6d16-5206-4779-aae7-301eb113e27f">
-----------------------------
### **R**ead 
Will get a specific entry. 
Finds an entry by documentId (which is also the track.getUuid() value) 

Code:
```js  
       Map<String, Object> updateRun = new HashMap<>();
       updateRun.put("id",127);
       updateRun.put("ascent",1);
       firestoreCRUD.updateEntry("runs", updateRun);
```
-----------------------------
### **U**pdate 
Will modify a specific entry. 
Finds an entry by documentId (which is also the track.getUuid() value) 

Code:
```js  
        Map<String, Object> getRun = new HashMap<>();
        getRun.put("id",123);
        firestoreCRUD.getEntry("runs", getRun);
 
```

Results:
<img width="1125" alt="image" src="https://github.com/Picard4/OpenTracks-Winter-2024-COMP-354-Groups-13-14-15/assets/31352301/729604b7-c9af-4bdd-86bc-8a85ccb26d48">

-----------------------------

Results:
<img width="670" alt="image" src="https://github.com/Picard4/OpenTracks-Winter-2024-COMP-354-Groups-13-14-15/assets/31352301/3dc675ca-7293-4933-94e1-f07eaa7950f0">

-----------------------------
### **D**elete
Will delete a specific entry. 
Finds an entry by documentId (which is also the track.getUuid() value) 


Code:
```js  
       Map<String, Object> deleteRun = new HashMap<>();
       deleteRun.put("id",134);
       firestoreCRUD.deleteEntry("runs", deleteRun); 
```
Results:
134 isn't present anymore
<img width="64" alt="image" src="https://github.com/Picard4/OpenTracks-Winter-2024-COMP-354-Groups-13-14-15/assets/31352301/eb4ce831-1dc5-4b21-83e6-3f47ad0d5dff">




**Link to the the issue**
(If available): The link to the issue that this pull request solves.

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
