### PR TITLE
CRUD tests + JSONSerializer Interface Test

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/data/FirestoreCRUDUtilTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/data/FirestoreCRUDUtilTest.java
@@ -1,0 +1,147 @@
+package de.dennisguse.opentracks.data;
+
+import org.junit.Test;
+import com.google.gson.JsonObject;
+import de.dennisguse.opentracks.data.interfaces.ActionCallback;
+import de.dennisguse.opentracks.data.interfaces.ReadCallback;
+import de.dennisguse.opentracks.data.models.CRUDConstants;
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Tests for FirestoreCRUDUtil class
+ */
+public class FirestoreCRUDUtilTest {
+
+    final String trackId = "track_01";
+
+    /**
+     * Expect SUCCESSFUL createEntry as the proper id and valid jsonData are passed
+     */
+    @Test
+    public void testCreateEntry() {
+        FirestoreCRUDUtil firestoreCRUDUtil = mock(FirestoreCRUDUtil.class);
+        ActionCallback callback = mock(ActionCallback.class);
+
+        JsonObject jsonData = generateMockData();
+        doAnswer(invocation -> {
+            // get the 4th param in the `createEntry` method
+            ((ActionCallback) invocation.getArgument(3)).onSuccess();
+            return null;
+        }).when(firestoreCRUDUtil).createEntry(anyString(), anyString(), any(JsonObject.class), any(ActionCallback.class));
+        firestoreCRUDUtil.createEntry(CRUDConstants.RUNS_TABLE, trackId, jsonData, callback);
+
+        verify(callback).onSuccess();
+    }
+
+    /**
+     * Expect SUCCESSFUL updateEntry as the proper id and valid jsonData are passed
+     */
+    @Test
+    public void testUpdateEntry() {
+        FirestoreCRUDUtil firestoreCRUDUtil = mock(FirestoreCRUDUtil.class);
+        ActionCallback callback = mock(ActionCallback.class);
+
+        JsonObject jsonData = generateMockData();
+        doAnswer(invocation -> {
+            // get the 4th param in the `updateEntry` method
+            ((ActionCallback) invocation.getArgument(3)).onSuccess();
+            return null;
+        }).when(firestoreCRUDUtil).updateEntry(anyString(), anyString(), any(JsonObject.class), any(ActionCallback.class));
+        firestoreCRUDUtil.updateEntry(CRUDConstants.RUNS_TABLE, trackId, jsonData, callback);
+
+        verify(callback).onSuccess();
+    }
+    /**
+     * Expect SUCCESSFUL deleteEntry as the proper id is passed
+     */
+    @Test
+    public void testDeleteEntry() {
+        FirestoreCRUDUtil firestoreCRUDUtil = mock(FirestoreCRUDUtil.class);
+        ActionCallback callback = mock(ActionCallback.class);
+
+        JsonObject jsonData = generateMockData();
+        doAnswer(invocation -> {
+            // get the 3rd param in the `deleteEntry` method
+            ((ActionCallback) invocation.getArgument(2)).onSuccess();
+            return null;
+        }).when(firestoreCRUDUtil).deleteEntry(anyString(), anyString(), any(ActionCallback.class));
+        firestoreCRUDUtil.deleteEntry(CRUDConstants.RUNS_TABLE, trackId, callback);
+
+        verify(callback).onSuccess();
+    }
+
+    /**
+     * Expect SUCCESSFUL getEntry as the proper id is passed
+     */
+    @Test
+    public void testGetEntry() {
+        FirestoreCRUDUtil firestoreCRUDUtil = mock(FirestoreCRUDUtil.class);
+        ReadCallback callback = mock(ReadCallback.class);
+
+        JsonObject jsonData = generateMockData();
+        doAnswer(invocation -> {
+            // get the 3rd param in the `getEntry` method
+            ((ActionCallback) invocation.getArgument(2)).onSuccess();
+            return null;
+        }).when(firestoreCRUDUtil).getEntry(anyString(), anyString(), any(ReadCallback.class));
+        firestoreCRUDUtil.getEntry(CRUDConstants.RUNS_TABLE, trackId, callback);
+
+        verify(callback).onSuccess(jsonData);
+    }
+
+    /**
+     * Generates mock data for testing purposes
+     * @return JsonObject with mock data
+     */
+    public static JsonObject generateMockData() {
+        JsonObject mockData = new JsonObject();
+
+        JsonObject idObject = new JsonObject();
+        idObject.addProperty("id", 42);
+        idObject.addProperty("name", "2024-04-04T12:12:12");
+
+        JsonObject altitudeExtremitiesObject = new JsonObject();
+        altitudeExtremitiesObject.addProperty("max", "-Infinity");
+        altitudeExtremitiesObject.addProperty("min", "Infinity");
+
+        JsonObject maxSpeedObject = new JsonObject();
+        maxSpeedObject.addProperty("speed_mps", 0);
+
+        JsonObject movingTimeObject = new JsonObject();
+        movingTimeObject.addProperty("skiing", false);
+        movingTimeObject.addProperty("slopePercentageSeason", 0);
+
+        JsonObject totalDistanceObject = new JsonObject();
+        totalDistanceObject.addProperty("distance_m", 0);
+        totalDistanceObject.addProperty("totalRunsSeason", 0);
+        totalDistanceObject.addProperty("totalSkiDaysSeason", 0);
+
+        JsonObject totalTimeObject = new JsonObject();
+        totalTimeObject.addProperty("waiting", false);
+
+        JsonObject trackStatisticsObject = new JsonObject();
+        trackStatisticsObject.add("altitudeExtremities", altitudeExtremitiesObject);
+        trackStatisticsObject.addProperty("chairlift", false);
+        trackStatisticsObject.addProperty("isIdle", false);
+        trackStatisticsObject.add("maxSpeed", maxSpeedObject);
+        trackStatisticsObject.add("movingTime", movingTimeObject);
+        trackStatisticsObject.add("startTime", new JsonObject());
+        trackStatisticsObject.add("stopTime", new JsonObject());
+        trackStatisticsObject.add("totalDistance", totalDistanceObject);
+        trackStatisticsObject.add("totalTime", totalTimeObject);
+        trackStatisticsObject.addProperty("uuid", "test");
+
+        mockData.addProperty("activityType", "SKI");
+        mockData.addProperty("activityTypeLocalized", "unknown");
+        mockData.addProperty("description", "Updated track");
+        mockData.addProperty("externalId", "track_01");
+        mockData.add("id", idObject);
+        mockData.add("trackStatistics", trackStatisticsObject);
+
+        return mockData;
+    }
+}
+
+
+

--- a/src/androidTest/java/de/dennisguse/opentracks/data/FirestoreCRUDUtilTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/data/FirestoreCRUDUtilTest.java
@@ -84,6 +84,7 @@ public class FirestoreCRUDUtilTest {
 
         verify(callback).onSuccess();
     }
+
     /**
      * Expect SUCCESSFUL deleteEntry as the proper id is passed
      */

--- a/src/androidTest/java/de/dennisguse/opentracks/data/FirestoreCRUDUtilTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/data/FirestoreCRUDUtilTest.java
@@ -34,6 +34,38 @@ public class FirestoreCRUDUtilTest {
         verify(callback).onSuccess();
     }
 
+
+    /**
+     * Expect SUCCESSFUL createEntry as the proper id and valid jsonData are passed and make sure
+     * getEntry retreives what we just created
+     */
+    @Test
+    public void testCreateAndRetrieveEntry() {
+        FirestoreCRUDUtil firestoreCRUDUtil = mock(FirestoreCRUDUtil.class);
+        ReadCallback readCallback = mock(ReadCallback.class);
+        ActionCallback createCallback = mock(ActionCallback.class);
+        JsonObject jsonData = generateMockData();
+
+        doAnswer(invocation -> {
+            // get the 4th param in the `createEntry` method
+            ((ActionCallback) invocation.getArgument(3)).onSuccess();
+            return null;
+        }).when(firestoreCRUDUtil).createEntry(anyString(), anyString(), any(JsonObject.class), any(ActionCallback.class));
+
+        doAnswer(invocation -> {
+            // get the 3rd param in the `getEntry` method
+            ((ReadCallback) invocation.getArgument(2)).onSuccess(jsonData);
+            return null;
+        }).when(firestoreCRUDUtil).getEntry(anyString(), anyString(), any(ReadCallback.class));
+
+        firestoreCRUDUtil.createEntry(CRUDConstants.RUNS_TABLE, trackId, jsonData, createCallback);
+        firestoreCRUDUtil.getEntry(CRUDConstants.RUNS_TABLE, trackId, readCallback);
+
+        verify(createCallback).onSuccess();
+        verify(readCallback).onSuccess(jsonData);
+    }
+
+
     /**
      * Expect SUCCESSFUL updateEntry as the proper id and valid jsonData are passed
      */
@@ -82,11 +114,12 @@ public class FirestoreCRUDUtilTest {
         JsonObject jsonData = generateMockData();
         doAnswer(invocation -> {
             // get the 3rd param in the `getEntry` method
-            ((ActionCallback) invocation.getArgument(2)).onSuccess();
+            ((ReadCallback) invocation.getArgument(2)).onSuccess(jsonData);
             return null;
         }).when(firestoreCRUDUtil).getEntry(anyString(), anyString(), any(ReadCallback.class));
         firestoreCRUDUtil.getEntry(CRUDConstants.RUNS_TABLE, trackId, callback);
 
+        System.out.println(jsonData.toString());
         verify(callback).onSuccess(jsonData);
     }
 

--- a/src/androidTest/java/de/dennisguse/opentracks/data/interfaces/JsonSerializerTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/data/interfaces/JsonSerializerTest.java
@@ -6,7 +6,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-
+/**
+ * Tests for JsonSerializer Interface
+ */
 public class JsonSerializerTest {
     final String description = "Completed track";
     final String externalId = "track_01";
@@ -14,7 +16,7 @@ public class JsonSerializerTest {
     @Test
     /**
      * Testing the toJSON method, making sure the expect key value pairs appear
-     * The unexpected keys should't resolve to true
+     * The unexpected keys shouldn't resolve to true
      */
     public void testIfValidToJson() {
         TestTrack testObject = new TestTrack(description, externalId);
@@ -46,23 +48,6 @@ public class JsonSerializerTest {
         public TestTrack(String description, String externalId) {
             this.description = description;
             this.externalId = externalId;
-        }
-        /**
-         * Get description
-         * @return description of type String
-         */
-
-
-        String getDescription() {
-            return this.description;
-        }
-
-        /**
-         * Get externalId
-         * @return externalId of type String
-         */
-        String getExternalId() {
-            return this.externalId;
         }
     }
 }

--- a/src/androidTest/java/de/dennisguse/opentracks/data/interfaces/JsonSerializerTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/data/interfaces/JsonSerializerTest.java
@@ -1,0 +1,68 @@
+package de.dennisguse.opentracks.data.interfaces;
+import org.junit.Test;
+import com.google.gson.JsonObject;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+
+public class JsonSerializerTest {
+    final String description = "Completed track";
+    final String externalId = "track_01";
+
+    @Test
+    /**
+     * Testing the toJSON method, making sure the expect key value pairs appear
+     * The unexpected keys should't resolve to true
+     */
+    public void testIfValidToJson() {
+        TestTrack testObject = new TestTrack(description, externalId);
+
+        JsonObject json = testObject.toJSON();
+
+        assertNotNull(json);
+        assertTrue(json.has("description"));
+        assertTrue(json.has("externalId"));
+        assertFalse(json.has("not there"));
+
+        assertEquals(description, json.get("description").getAsString());
+        assertEquals(externalId, json.get("externalId").getAsString());
+    }
+
+    // TODO: add tests for FromJSON
+
+    /**
+     * Sample class of Track that extends the JSONSerializable
+     * This class is a simplified version of the Track class that has only a few fields
+     */
+    private static class TestTrack implements JSONSerializable<TestTrack> {
+        private String description;
+        private String externalId;
+
+        /**
+         * The constructor will set static value for the purpose of the test
+         */
+        public TestTrack(String description, String externalId) {
+            this.description = description;
+            this.externalId = externalId;
+        }
+        /**
+         * Get description
+         * @return description of type String
+         */
+
+
+        String getDescription() {
+            return this.description;
+        }
+
+        /**
+         * Get externalId
+         * @return externalId of type String
+         */
+        String getExternalId() {
+            return this.externalId;
+        }
+    }
+}

--- a/src/main/java/de/dennisguse/opentracks/data/FirestoreCRUDUtil.java
+++ b/src/main/java/de/dennisguse/opentracks/data/FirestoreCRUDUtil.java
@@ -63,6 +63,7 @@ public class FirestoreCRUDUtil implements ExternalStorageUtil {
                     Log.e(CRUDConstants.TAG_ERROR, CRUDConstants.ERROR_CREATING_DOCUMENT + e.getMessage());
                     if (callback != null) callback.onFailure();
                 });
+
     }
 
     /**


### PR DESCRIPTION
## Describe the pull request
This pull request includes CRUD operations test cases expecting to successfully Create, Read, Update and Delete mock data from a mock call to firesotre.
As well, this MR begins the testing of the JSONSerialize Interface to make sure that we properly serialize the data we are given. 

## Validation
**FirestoreCRUDUtilTest.java**
 
<img width="861" alt="image" src="https://github.com/rilling/OpenTracks-Winter-2024-COMP-354/assets/31352301/4024e5a1-d8ba-4260-9454-c176766d41e0">


**JsonSerializerTest.java**
<img width="860" alt="image" src="https://github.com/rilling/OpenTracks-Winter-2024-COMP-354/assets/31352301/d4464a1f-fad1-4136-b540-0e72f032067d">

**Link to the the issue**
TBD

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
